### PR TITLE
Support newer versions of Activerecord.

### DIFF
--- a/one_offs.gemspec
+++ b/one_offs.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency(%q<activerecord>, ['~> 1.15', '>= 1.15.6'])
+  s.add_dependency(%q<activerecord>, ['>= 1.15.6', '< 5'])
 end


### PR DESCRIPTION
* The old constraint of '~> 1.15' causes issues
with bundle updates on Rails 4 apps. We support all
versions of Activerecord < 5.

* This fixes clashes with gems with newer Activerecord
deps.