### PR TITLE
Vishnu: Adding ability to create tracker table without migration. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 .bundle
+.idea
 Gemfile.lock
 pkg/*
 *~

--- a/README.md
+++ b/README.md
@@ -26,12 +26,26 @@ After installing the gem, In your Rakefile (/Rakefile) add the following line
     require 'one_offs/tasks'
 
 
-And setup a tracker table.
-
+And setup a tracker table (creates migration).
 
     rake one_offs:generate_tracker_table
 
+OR using SQL query if you want to avoid a migration (Useful if you need to setup one off tasks before db:migrate).
+
+    rake one_offs:create_tracker_table_using_sql
+
 Add scripts to `lib/one_offs/`
+  * File name should be <code>\<number\>_class_name_inside_file.rb</code> (Rails convention for file name to class name with the order number before that)
+
+    Example:
+
+        File: 1_hello_world.rb
+        Contents:
+            class HelloWorld
+                def self.process
+                puts("You may write your code in this process method").
+            end
+        end
 
 To run pending one_off scripts.
 

--- a/lib/one_offs/tasks.rb
+++ b/lib/one_offs/tasks.rb
@@ -10,4 +10,10 @@ namespace :one_offs do
   task :generate_tracker_table do
     `rails generate migration CreateOneOffTracker name:string`
   end
+
+  desc 'Create one off tracker table using SQL instead of migration'
+  task :create_tracker_table_using_sql => :environment do
+    sql = 'CREATE TABLE IF NOT EXISTS "one_off_trackers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar);'
+    ActiveRecord::Base.connection.execute(sql)
+  end
 end


### PR DESCRIPTION
We have a use case on our project where we need to run one time tasks. But it's a legacy codebase and due to some dependency, we need to run a one off task before the `db:migrate` runs.

For this reason, I've added a rake task to create the "tracker" table using SQL query. This way we don't depend only on migrations for integrating this gem.

This is useful if you need to set up the one off tasks without using migrations.

The only other option is to not use one_offs gem and use regular rake tasks within the project.

I've updated the Readme as well to reflect instructions pertaining to this change and something needed even without the change (the file_name format for one_offs scripts).